### PR TITLE
Feat/bug reports #61

### DIFF
--- a/feat/bug-reports/Raport błędu — UA-BUG-001
+++ b/feat/bug-reports/Raport błędu — UA-BUG-001
@@ -1,0 +1,162 @@
+# Raport błędu — UA-BUG-001
+
+## Status ogólny
+
+> ⚠️ Krytyczny błąd bezpieczeństwa wykryty podczas analizy kodu źródłowego — poza głównym scenariuszem testowym. Endpointy do zarządzania szablonami pytań są dostępne dla nieuwierzytelnionych użytkowników.
+
+---
+
+## BUG-001 — Brak autoryzacji na endpointach POST i DELETE `/api/admin/questions`
+
+| Pole | Wartość |
+|---|---|
+| **ID błędu** | UA-BUG-002 |
+| **Tytuł** | Endpointy `POST /api/admin/questions/` i `DELETE /api/admin/questions/{id}` nie wymagają uwierzytelnienia — dostęp anonimowy możliwy |
+| **Severity** | **High** — nieautoryzowany użytkownik może tworzyć i usuwać szablony pytań, co prowadzi do utraty danych i naruszenia integralności ankiet |
+| **Środowisko** | Backend: `http://localhost:8000` / FastAPI 0.135.1 / SQLAlchemy 2.0.48 / Docker: `uniankieta_api` |
+
+---
+
+## Opis błędu
+
+W pliku `backend/app/api/questions.py` zdefiniowane są trzy endpointy routera:
+
+- `POST /` — tworzy nowy szablon pytania
+- `GET /` — zwraca listę pytań
+- `DELETE /{question_id}` — usuwa pytanie
+
+Router ten jest montowany w `main.py` pod prefiksem `/api/admin/questions`, co sugeruje, że dostęp powinien być ograniczony wyłącznie do roli Admin. Jednak żaden z tych endpointów **nie używa zależności `get_current_admin_user`** ani żadnej innej formy weryfikacji tożsamości. Dowolny klient HTTP — bez nagłówka `Authorization` — może wywołać `POST` lub `DELETE`.
+
+Dla porównania: endpointy w `backend/app/api/tours.py` i `backend/app/api/teacher.py` poprawnie stosują `Depends(get_current_admin_user)` lub `Depends(get_current_admin_or_teacher)`.
+
+---
+
+## Kroki reprodukcji
+
+1. Uruchom środowisko: `docker-compose up --build`
+2. **Bez logowania** — nie pobieraj żadnego tokenu JWT
+3. Wywołaj żądanie tworzenia pytania:
+   ```
+   POST http://localhost:8000/api/admin/questions/
+   Content-Type: application/json
+
+   {
+     "text": "Pytanie wstrzykniete bez uprawnien",
+     "question_type": "open",
+     "choices": []
+   }
+   ```
+4. Sprawdź odpowiedź — oczekiwane: `HTTP 401 Unauthorized`, otrzymane: `HTTP 201 Created`
+5. Wywołaj żądanie usunięcia pytania o `id=1`:
+   ```
+   DELETE http://localhost:8000/api/admin/questions/1
+   ```
+6. Sprawdź odpowiedź — oczekiwane: `HTTP 401 Unauthorized`, otrzymane: `HTTP 204 No Content`
+
+---
+
+## Wynik aktualny
+
+- `POST /api/admin/questions/` zwraca **HTTP 201 Created** bez tokenu JWT — pytanie zostaje zapisane w bazie.
+- `DELETE /api/admin/questions/{id}` zwraca **HTTP 204 No Content** bez tokenu JWT — pytanie zostaje trwale usunięte razem z powiązanymi odpowiedziami (CASCADE).
+- W `GET /api/admin/questions/` brak uwierzytelnienia nie jest groźny (odczyt), ale pozostaje niespójny z polityką dostępu dla ścieżki `/api/admin/`.
+
+---
+
+## Wynik oczekiwany
+
+- `POST /api/admin/questions/` bez nagłówka `Authorization: Bearer <token>` zwraca **HTTP 401 Unauthorized**.
+- `DELETE /api/admin/questions/{id}` bez ważnego tokenu zwraca **HTTP 401 Unauthorized**.
+- Wywołanie z tokenem roli `Student` lub `Teacher` zwraca **HTTP 403 Forbidden**.
+- Wywołanie z tokenem roli `Admin` działa poprawnie i zwraca odpowiednio `HTTP 201` lub `HTTP 204`.
+
+---
+
+## Propozycja naprawy
+
+**Plik:** `backend/app/api/questions.py`
+
+Dodać import zależności autoryzacyjnej i zastosować ją do każdego endpointu modyfikującego dane:
+
+```python
+# backend/app/api/questions.py
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+from typing import List
+
+from app.database import get_db
+from app.models import Question, QuestionChoice, QuestionType
+from app.schemas import QuestionCreate, QuestionResponse
+# NAPRAWA: dodaj import zależności autoryzacji
+from app.core.security import get_current_admin_user
+
+router = APIRouter()
+
+
+# --- ENDPOINT: CREATE QUESTION (NAPRAWIONY) ---
+@router.post("/", response_model=QuestionResponse, status_code=status.HTTP_201_CREATED)
+def create_question(
+    question_in: QuestionCreate,
+    db: Session = Depends(get_db),
+    _admin=Depends(get_current_admin_user)  # NAPRAWA: wymaga roli Admin
+):
+    if question_in.question_type == QuestionType.CLOSED:
+        if not question_in.choices or len(question_in.choices) < 2:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="A closed-ended question must have at least 2 answer choices."
+            )
+
+    new_question = Question(
+        text=question_in.text,
+        question_type=question_in.question_type,
+        is_active=True
+    )
+    db.add(new_question)
+    db.commit()
+    db.refresh(new_question)
+
+    if question_in.question_type == QuestionType.CLOSED:
+        for choice_text in question_in.choices:
+            db.add(QuestionChoice(question_id=new_question.id, text=choice_text))
+        db.commit()
+        db.refresh(new_question)
+
+    return new_question
+
+
+# --- ENDPOINT: GET ALL QUESTIONS (opcjonalnie — ogranicz do zalogowanych) ---
+@router.get("/", response_model=List[QuestionResponse])
+def get_all_questions(
+    db: Session = Depends(get_db),
+    _admin=Depends(get_current_admin_user)  # NAPRAWA: spójność z resztą /api/admin/
+):
+    return db.query(Question).all()
+
+
+# --- ENDPOINT: DELETE QUESTION (NAPRAWIONY) ---
+@router.delete("/{question_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_question(
+    question_id: int,
+    db: Session = Depends(get_db),
+    _admin=Depends(get_current_admin_user)  # NAPRAWA: wymaga roli Admin
+):
+    question = db.query(Question).filter(Question.id == question_id).first()
+    if not question:
+        raise HTTPException(status_code=404, detail="Question not found")
+
+    db.delete(question)
+    db.commit()
+    return None
+```
+
+---
+
+## Dodatkowe obserwacje
+
+| Obszar | Obserwacja | Rekomendacja |
+|---|---|---|
+| Spójność routerów | Endpointy w `tours.py` i `teacher.py` poprawnie stosują `Depends(get_current_admin_user)`. Brak tej zależności w `questions.py` to prawdopodobnie pominięcie podczas refaktoryzacji. | Przegląd kodu (code review) dla wszystkich routerów montowanych pod `/api/admin/` przed wdrożeniem produkcyjnym. |
+| Zasada minimalnych uprawnień | `GET /api/admin/questions/` jest wywoływane również przez panel Nauczyciela (`teacher.py` zawiera własny `GET /api/teacher/questions`). Rozważyć, czy odczyt dla `/api/admin/questions/` powinien być dostępny tylko dla Admina, czy też dla roli Admin+Teacher. | Ujednolicić politykę dostępu — zastosować `get_current_admin_or_teacher` dla operacji odczytu, `get_current_admin_user` dla zapisu i usuwania. |
+| Testy automatyczne | Brak widocznych testów jednostkowych lub integracyjnych dla endpointów `questions.py`. | Dodać testy sprawdzające odpowiedź `HTTP 401` dla żądań bez tokenu oraz `HTTP 403` dla tokenu roli Student. |

--- a/feat/bug-reports/Raport błędu — UA-BUG-002
+++ b/feat/bug-reports/Raport błędu — UA-BUG-002
@@ -1,0 +1,171 @@
+# Raport błędu — UA-BUG-002
+
+## Status ogólny
+
+> ⚠️ Błąd wykryty podczas analizy kodu źródłowego — poza głównym scenariuszem testowym. Endpoint przyjmowania odpowiedzi ankiety akceptuje surowy `dict` bez walidacji schematu, co umożliwia zapis odpowiedzi do nieistniejących pytań oraz uszkodzenie danych analitycznych.
+
+---
+
+## BUG-002 — Endpoint `POST /api/responses/submit` akceptuje niesprawdzony `dict` — brak walidacji `question_id` i wartości odpowiedzi
+
+| Pole | Wartość |
+|---|---|
+| **ID błędu** | UA-BUG-003 |
+| **Tytuł** | `POST /api/responses/submit` przyjmuje `submission: dict` bez Pydantic schema — możliwy zapis odpowiedzi do nieistniejących pytań i pomijanie wymaganych pól |
+| **Severity** | **High** — uszkodzenie integralności danych analitycznych; odpowiedzi powiązane z nieistniejącymi `question_id` powodują ciche błędy w raportach i eksporcie CSV/PDF |
+| **Środowisko** | Backend: `http://localhost:8000` / FastAPI 0.135.1 / SQLAlchemy 2.0.48 / Python 3.11 / Docker: `uniankieta_api` |
+
+---
+
+## Opis błędu
+
+W pliku `backend/app/api/responses.py` sygnatura endpointu to:
+
+```python
+@router.post("/submit")
+def submit_survey(submission: dict, db: Session = Depends(get_db)):
+```
+
+Użycie `dict` zamiast zdefiniowanego modelu Pydantic powoduje kilka problemów jednocześnie:
+
+**Problem 1 — Brak walidacji `question_id`:** Iteracja `for ans in submission.get("answers", [])` nie sprawdza, czy `question_id` istnieje w tabeli `questions`. Jeśli klient prześle `question_id=9999` (nieistniejące pytanie), SQLAlchemy wykona `INSERT` do tabeli `answers` z nieistniejącym kluczem obcym. Baza PostgreSQL wymusi integralność (FK constraint), lecz wyjątek nie jest obsługiwany — użytkownik otrzyma `HTTP 500 Internal Server Error` bez żadnego komunikatu, a token zostanie oznaczony jako `is_used=True` mimo niepowodzenia (patrz: Problem 2).
+
+**Problem 2 — Race condition przy oznaczaniu tokenu:** Zapis odpowiedzi i oznaczenie `db_token.is_used = True` są wykonywane w ramach jednego `db.commit()`. Jeśli którykolwiek `INSERT` do `answers` rzuci wyjątek (np. FK violation), `commit` nie dojdzie do skutku — co jest prawidłowe. Jednak brakuje obsługi tego wyjątku (`try/except`), więc serwer zwraca HTTP 500, a student nie wie, czy ankieta została zapisana. Może ponownie spróbować przesłać formularz, lecz token pozostaje `is_used=False`, co tworzy ryzyko wielokrotnego zapisu przy ponownej próbie.
+
+**Problem 3 — Brak walidacji pól `value`:** Pole `value` odpowiedzi jest typowane jako `String` w modelu `Answer`, ale nie ma żadnego limitu długości. Przesłanie wartości o długości 100 000 znaków zostanie zapisane bez błędu.
+
+---
+
+## Kroki reprodukcji
+
+### Scenariusz A — nieistniejące `question_id`
+
+1. Uruchom środowisko: `docker-compose up --build`
+2. Zaloguj się jako Student (przycisk `Student` na stronie logowania), pobierz token ankiety dla aktywnej tury
+3. Wywołaj żądanie:
+   ```
+   POST http://localhost:8000/api/responses/submit
+   Content-Type: application/json
+
+   {
+     "token": "<ważny_token_studenta>",
+     "answers": [
+       {"question_id": 99999, "value": "odpowiedz testowa"}
+     ]
+   }
+   ```
+4. Sprawdź odpowiedź — oczekiwane: `HTTP 400 Bad Request` z komunikatem `"question_id 99999 does not exist"`, otrzymane: `HTTP 500 Internal Server Error`
+
+### Scenariusz B — brakujące pole `value`
+
+1. Wywołaj żądanie z pominięciem klucza `value`:
+   ```json
+   {"token": "<ważny_token>", "answers": [{"question_id": 1}]}
+   ```
+2. Otrzymane: `HTTP 500 Internal Server Error` (`KeyError: 'value'` w logach kontenera), zamiast `HTTP 422 Unprocessable Entity`
+
+---
+
+## Wynik aktualny
+
+- Przesłanie odpowiedzi z nieistniejącym `question_id` zwraca **HTTP 500** (nieobsługiwany wyjątek IntegrityError z PostgreSQL).
+- Brakujące pole `value` zwraca **HTTP 500** (KeyError), zamiast walidacyjnego **HTTP 422**.
+- Brak jasnego komunikatu błędu po stronie frontendu — użytkownik widzi ogólny Toast `"Błąd serwera"`.
+- W logach kontenera `uniankieta_api` widoczny stack trace SQLAlchemy / KeyError.
+
+---
+
+## Wynik oczekiwany
+
+- Przesłanie odpowiedzi z nieistniejącym `question_id` zwraca **HTTP 400 Bad Request** z komunikatem opisującym przyczynę.
+- Brakujące pole zwraca **HTTP 422 Unprocessable Entity** (standardowa walidacja FastAPI/Pydantic).
+- Poprawnie wypełniona ankieta zwraca **HTTP 200 OK** z komunikatem `"Survey submitted successfully and anonymously!"`.
+- Token jest oznaczany jako `is_used=True` **wyłącznie** po pomyślnym zapisaniu wszystkich odpowiedzi.
+
+---
+
+## Propozycja naprawy
+
+**Plik:** `backend/app/api/responses.py`
+
+Zastąpić `dict` dedykowanymi modelami Pydantic i dodać walidację `question_id` oraz obsługę wyjątków:
+
+```python
+# backend/app/api/responses.py
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+from pydantic import BaseModel, Field
+from typing import List
+
+from app.database import get_db
+from app.models import SurveyToken, Answer, Question
+
+router = APIRouter(prefix="/api/responses", tags=["Responses"])
+
+
+# NAPRAWA: Zdefiniuj jawne schematy Pydantic zamiast surowego dict
+class AnswerItem(BaseModel):
+    question_id: int
+    value: str = Field(..., min_length=1, max_length=5000)
+
+
+class SurveySubmission(BaseModel):
+    token: str
+    answers: List[AnswerItem] = Field(..., min_length=1)
+
+
+@router.post("/submit")
+def submit_survey(
+    submission: SurveySubmission,  # NAPRAWA: typed schema zamiast dict
+    db: Session = Depends(get_db)
+):
+    # 1. Weryfikacja tokenu
+    db_token = db.query(SurveyToken).filter(
+        SurveyToken.token == submission.token
+    ).first()
+
+    if not db_token:
+        raise HTTPException(status_code=404, detail="Token not found")
+
+    if db_token.is_used:
+        raise HTTPException(status_code=400, detail="You have already submitted this survey!")
+
+    # NAPRAWA: Walidacja question_id przed zapisem
+    question_ids = {ans.question_id for ans in submission.answers}
+    existing_ids = {
+        q.id for q in db.query(Question).filter(Question.id.in_(question_ids)).all()
+    }
+    missing_ids = question_ids - existing_ids
+    if missing_ids:
+        raise HTTPException(
+            status_code=400,
+            detail=f"question_id(s) not found: {sorted(missing_ids)}"
+        )
+
+    # 2. Zapis odpowiedzi i oznaczenie tokenu w jednej transakcji
+    try:
+        for ans in submission.answers:
+            db.add(Answer(question_id=ans.question_id, value=ans.value))
+
+        db_token.is_used = True
+        db.commit()
+    except Exception:
+        db.rollback()
+        raise HTTPException(
+            status_code=500,
+            detail="Błąd zapisu odpowiedzi. Spróbuj ponownie."
+        )
+
+    return {"message": "Survey submitted successfully and anonymously!"}
+```
+
+---
+
+## Dodatkowe obserwacje
+
+| Obszar | Obserwacja | Rekomendacja |
+|---|---|---|
+| Walidacja tokenu ankiety | Endpoint nie sprawdza, czy tura powiązana z tokenem (`db_token.tour_id`) jest aktywna i mieści się w oknie czasowym (`start_date <= now <= end_date`). Student z ważnym, niezużytym tokenem może przesłać odpowiedź po zakończeniu tury. | Dodać weryfikację: pobrać `SurveyTour` po `tour_id`, sprawdzić `is_active` i zakres dat przed przyjęciem odpowiedzi. |
+| Atomowość transakcji | Obecny kod wykonuje pętle `db.add()` poza blokiem `try/except`. Awaria w połowie zapisu skutkuje częściowymi danymi w bazie i nieokreślonym stanem tokenu. | Cały blok zapisu (pętla + `is_used = True`) powinien być objęty `try/except` z `db.rollback()` w gałęzi błędu — co propozycja naprawy powyżej implementuje. |
+| Limit odpowiedzi | Nie ma ograniczenia liczby elementów w tablicy `answers`. Klient może przesłać tysiące wpisów w jednym żądaniu. | Dodać `max_length` w `Field(..., max_length=200)` dla listy `answers` lub walidację na poziomie liczby aktywnych pytań w turze. |

--- a/feat/bug-reports/Raport błędu — UA-BUG-003
+++ b/feat/bug-reports/Raport błędu — UA-BUG-003
@@ -1,0 +1,155 @@
+# Raport błędu — UA-BUG-003
+
+## Status ogólny
+
+> ⚠️ Błąd wykryty podczas analizy kodu źródłowego — poza głównym scenariuszem testowym. Endpoint SSO callback używa statycznie zapisanego adresu URL frontendu zamiast wartości ze zmiennej środowiskowej, co powoduje zerwanie przepływu uwierzytelniania SSO w środowiskach innych niż `localhost`.
+
+---
+
+## BUG-003 — Hardkodowany adres frontendu w `auth.py` — SSO callback zawsze przekierowuje na `http://localhost:5173`
+
+| Pole | Wartość |
+|---|---|
+| **ID błędu** | UA-BUG-004 |
+| **Tytuł** | `GET /api/auth/callback` przekierowuje na `http://localhost:5173` bez względu na wartość zmiennej środowiskowej `FRONTEND_URL` — przepływ SSO zepsuty w środowisku Docker i produkcyjnym |
+| **Severity** | **Medium** — funkcjonalność logowania przez SSO uczelni jest niedostępna w środowisku Docker (kontener-do-kontenera) i w środowisku produkcyjnym; obejście: logowanie email/hasło lub przyciski deweloperskie |
+| **Środowisko** | Backend: `http://localhost:8000` / `docker-compose` sieć wewnętrzna / FastAPI 0.135.1 / Docker: `uniankieta_api`, `uniankieta_web` |
+
+---
+
+## Opis błędu
+
+W pliku `backend/app/api/auth.py` linia przekierowania po pomyślnym uwierzytelnieniu SSO jest hardkodowana:
+
+```python
+# backend/app/api/auth.py, linia 1349
+frontend_url = f"http://localhost:5173/?token={access_token}"
+return RedirectResponse(url=frontend_url)
+```
+
+Tymczasem `docker-compose.yml` definiuje zmienną środowiskową `FRONTEND_URL` przekazywaną do kontenera backendu:
+
+```yaml
+# docker-compose.yml
+backend:
+  environment:
+    - DATABASE_URL=postgresql://user:password@db:5432/uniankieta
+    - FRONTEND_URL=http://localhost:5173
+```
+
+Wartość `FRONTEND_URL` jest poprawnie odczytywana w `main.py`:
+
+```python
+# main.py, linia 228
+FRONTEND_URL = os.getenv("FRONTEND_URL", "http://localhost:5173")
+```
+
+...lecz ta zmienna **nie jest importowana ani używana** w `auth.py`. Efektem jest sytuacja, w której zmiana wartości `FRONTEND_URL` w `docker-compose.yml` lub pliku `.env` nie ma żadnego wpływu na działanie callbacku SSO.
+
+W środowisku Docker, jeśli `FRONTEND_URL` zostałoby ustawione na wewnętrzną nazwę serwisu (np. `http://uniankieta_web:5173`) lub zewnętrzną domenę produkcyjną (np. `https://ankieta.uczelnia.pl`), redirect i tak trafiałby na `http://localhost:5173`, który jest niedostępny z poziomu przeglądarki użytkownika łączącego się z hostem innym niż `localhost`.
+
+Dodatkowo, `main.py` definiuje zmienną `FRONTEND_URL` lokalnie, ale nie eksportuje jej do innych modułów — co wymusza duplikację odczytu `os.getenv` w `auth.py`.
+
+---
+
+## Kroki reprodukcji
+
+1. W pliku `docker-compose.yml` zmień wartość zmiennej środowiskowej backendu:
+   ```yaml
+   backend:
+     environment:
+       - FRONTEND_URL=http://192.168.1.100:5173
+   ```
+2. Uruchom środowisko: `docker-compose up --build`
+3. Przejdź do strony logowania i kliknij przycisk **"Zaloguj przez SSO uczelni"** (wywołuje `GET /api/auth/sso-login`, który przekierowuje na `/api/auth/sso-callback?code=test_user_123`, a następnie na `/api/auth/callback`)
+4. Zaobserwuj przekierowanie przeglądarki
+5. Sprawdź docelowy adres URL w pasku przeglądarki
+
+---
+
+## Wynik aktualny
+
+- Przeglądarka zostaje przekierowana na `http://localhost:5173/?token=<JWT>` **niezależnie** od wartości `FRONTEND_URL` ustawionej w `docker-compose.yml`.
+- Na maszynie, gdzie `localhost:5173` jest niedostępne (serwer CI, środowisko testowe, produkcja), przeglądarka wyświetla błąd połączenia.
+- Token JWT zawarty w URL jest tracony — użytkownik nie zostaje zalogowany.
+- Przepływ SSO kończy się niepowodzeniem; `Toast` na stronie głównej nie wyświetla komunikatu, ponieważ strona w ogóle się nie ładuje.
+
+---
+
+## Wynik oczekiwany
+
+- Po pomyślnym uwierzytelnieniu SSO przeglądarka zostaje przekierowana na adres zbudowany z wartości zmiennej środowiskowej `FRONTEND_URL`.
+- Zmiana `FRONTEND_URL=https://ankieta.uczelnia.pl` w konfiguracji środowiska skutkuje przekierowaniem na `https://ankieta.uczelnia.pl/?token=<JWT>`.
+- W środowisku deweloperskim (domyślna wartość `http://localhost:5173`) zachowanie pozostaje bez zmian.
+
+---
+
+## Propozycja naprawy
+
+**Plik:** `backend/app/api/auth.py`
+
+Zastąpić hardkodowany adres odczytem zmiennej środowiskowej `FRONTEND_URL`:
+
+```python
+# backend/app/api/auth.py
+
+import os  # NAPRAWA: dodaj import os
+from fastapi import APIRouter, Depends
+from fastapi.responses import RedirectResponse
+from sqlalchemy.orm import Session
+
+from app.core.auth_service import authenticate_or_create_user
+from app.core.security import create_access_token
+from app.database import get_db
+
+router = APIRouter(prefix="/auth", tags=["SSO Authentication"])
+
+# NAPRAWA: odczytaj FRONTEND_URL ze środowiska (z fallbackiem na localhost)
+FRONTEND_URL = os.getenv("FRONTEND_URL", "http://localhost:5173")
+
+
+@router.get("/login")
+async def login():
+    """Entry point: simulates a redirect from the University SSO"""
+    return RedirectResponse(url="/api/auth/callback?code=mock_usos_super_code_777")
+
+
+@router.get("/callback")
+async def auth_callback(code: str, db: Session = Depends(get_db)):
+    """Handle SSO response and create session"""
+
+    mock_university_profile = {
+        "sso_id": "admin_12345",
+        "email": "admin@admin.pl",
+        "name": "Jan Kowalski (Admin)"
+    }
+
+    user = authenticate_or_create_user(
+        db=db,
+        sso_email=mock_university_profile["email"],
+        sso_id=mock_university_profile["sso_id"]
+    )
+
+    access_token = create_access_token(user_id=user.id, role=user.role)
+
+    # NAPRAWA: użyj zmiennej FRONTEND_URL zamiast hardkodowanego adresu
+    redirect_url = f"{FRONTEND_URL}/?token={access_token}"
+    return RedirectResponse(url=redirect_url)
+
+
+@router.post("/logout")
+async def logout():
+    return {"message": "Successfully logged out."}
+```
+
+Dodatkowo, aby uniknąć duplikacji w przyszłości, zalecane jest wyodrębnienie `FRONTEND_URL` do wspólnego modułu konfiguracyjnego (`backend/app/core/config.py`) i importowanie stamtąd w `main.py` oraz `auth.py`.
+
+---
+
+## Dodatkowe obserwacje
+
+| Obszar | Obserwacja | Rekomendacja |
+|---|---|---|
+| SSO callback — mock stały | Endpoint `/api/auth/callback` zawsze zwraca dane profilu `admin@admin.pl` niezależnie od parametru `code`. W środowisku produkcyjnym parametr `code` powinien być wysłany do prawdziwego dostawcy SSO (USOS API) w celu pobrania danych użytkownika. | Dodać integrację z USOS OAuth2 w kolejnym sprincie; do tego czasu wyraźnie oznaczyć endpoint jako `[MOCK]` w dokumentacji Swagger (tag lub opis). |
+| Token JWT w URL | Przekazywanie tokenu JWT jako parametru query string (`?token=...`) jest anty-wzorcem bezpieczeństwa — token może być logowany przez serwery proxy, zapisany w historii przeglądarki i w nagłówku `Referer`. | Rozważyć przekazanie tokenu przez krótkotrwały kod jednorazowy (PKCE) lub przez bezpieczny cookie `HttpOnly; SameSite=Strict` po stronie backendu. |
+| Zmienna `FRONTEND_URL` w `main.py` | Zmienna jest odczytywana lokalnie w `main.py`, ale nie jest eksportowana — każdy moduł musi ją odczytywać niezależnie, co prowadzi do duplikacji i obecnego błędu. | Stworzyć `backend/app/core/config.py` z klasą `Settings` (Pydantic BaseSettings), która centralnie zarządza konfiguracją środowiskową. |


### PR DESCRIPTION
## Opis zmian

Dodano dokumentację błędów (Bug Reports) na podstawie analizy kodu oraz wcześniejszych problemów występujących w systemie UniAnkieta. Celem zmian nie jest naprawa błędów, lecz ich identyfikacja, opisanie i zarejestrowanie zgodnie z wymaganiami kategorii „Rejestracja błędów”.

Zakres prac obejmuje:

- przeanalizowanie kodu backendu i wskazanie miejsc podatnych na błędy,
- przygotowanie raportów błędów w formacie Markdown,
- opisanie błędów, które występowały wcześniej lub nadal mogą wystąpić,
- dodanie dokumentacji do repozytorium,
- utworzenie GitHub Issues oznaczonych etykietą `bug`.

Raporty obejmują:
- UA-BUG-001 – Brak autoryzacji 
- UA-BUG-002 – Brak walidacji schematu odpowiedzi ankiety 
- UA-BUG-003 – Hardkodowany adres frontendu w SSO callback

## Checklista

- [x] Raporty błędów zostały przygotowane
- [x] Issues typu `bug` zostały utworzone
- [x] Dokumentacja została dodana do repozytorium
- [x] Raporty opisują błędy, ale nie zawierają ich naprawy
